### PR TITLE
replace "HashSet" with "LinkedHashSet" 

### DIFF
--- a/appserver/web/war-util/src/main/java/org/glassfish/web/loader/WebappClassLoader.java
+++ b/appserver/web/war-util/src/main/java/org/glassfish/web/loader/WebappClassLoader.java
@@ -1679,7 +1679,7 @@ public class WebappClassLoader
 
     @SuppressWarnings("unchecked")
     private URL[] removeDuplicate(ArrayList<URL> urls) {
-        HashSet h = new HashSet(urls);
+        LinkedHashSet h = new LinkedHashSet(urls);
         urls.clear();
         urls.addAll(h);
         return urls.toArray(new URL[urls.size()]);


### PR DESCRIPTION
JSP compilation sometimes fails because the Hashset is no guarantees as to the order of the set
https://github.com/eclipse-ee4j/glassfish/issues/22891